### PR TITLE
Replaced `FarmingLib.reduceFarming` with `stopFarming`

### DIFF
--- a/contracts/FarmingPlugin.sol
+++ b/contracts/FarmingPlugin.sol
@@ -13,7 +13,7 @@ import { IFarmingPlugin } from "./interfaces/IFarmingPlugin.sol";
 import { FarmingLib, FarmAccounting } from "./FarmingLib.sol";
 import { WithdrawableGetters } from "./WithdrawableGetters.sol";
 
-contract FarmingPlugin is WithdrawableGetters, Plugin, IFarmingPlugin, Ownable {
+contract FarmingPlugin is Plugin, IFarmingPlugin, Ownable, WithdrawableGetters {
     using SafeERC20 for IERC20;
     using FarmingLib for FarmingLib.Info;
     using FarmAccounting for FarmAccounting.Info;

--- a/contracts/FarmingPool.sol
+++ b/contracts/FarmingPool.sol
@@ -119,7 +119,7 @@ contract FarmingPool is WithdrawableGetters, IFarmingPool, Ownable, ERC20 {
                 amount = token.balanceOf(address(this));
                 if (token == stakingToken) {
                     uint256 staked = totalSupply();
-                    amount = amount >= staked ? amount - staked: 0;
+                    amount = amount > staked ? amount - staked: 0;
                 }
             }
             token.safeTransfer(_distributor, amount);
@@ -135,7 +135,8 @@ contract FarmingPool is WithdrawableGetters, IFarmingPool, Ownable, ERC20 {
         }
         if (token == stakingToken) {
             uint256 amount = token.balanceOf(address(this));
-            return amount >= totalSupply() ? amount - totalSupply(): 0;
+            uint256 staked = totalSupply();
+            return amount > staked ? amount - staked: 0;
         }
         return token.balanceOf(address(this));
     }

--- a/contracts/FarmingPool.sol
+++ b/contracts/FarmingPool.sol
@@ -12,7 +12,7 @@ import { IFarmingPool } from "./interfaces/IFarmingPool.sol";
 import { FarmAccounting, FarmingLib } from "./FarmingLib.sol";
 import { WithdrawableGetters } from "./WithdrawableGetters.sol";
 
-contract FarmingPool is WithdrawableGetters, IFarmingPool, Ownable, ERC20 {
+contract FarmingPool is IFarmingPool, Ownable, ERC20, WithdrawableGetters {
     using SafeERC20 for IERC20;
     using Address for address payable;
     using FarmingLib for FarmingLib.Info;

--- a/contracts/MultiFarmingPlugin.sol
+++ b/contracts/MultiFarmingPlugin.sol
@@ -14,7 +14,7 @@ import { IMultiFarmingPlugin } from "./interfaces/IMultiFarmingPlugin.sol";
 import { FarmAccounting, FarmingLib } from "./FarmingLib.sol";
 import { WithdrawableGetters } from "./WithdrawableGetters.sol";
 
-contract MultiFarmingPlugin is WithdrawableGetters, Plugin, IMultiFarmingPlugin, Ownable {
+contract MultiFarmingPlugin is Plugin, IMultiFarmingPlugin, Ownable, WithdrawableGetters {
     using SafeERC20 for IERC20;
     using FarmingLib for FarmingLib.Info;
     using Address for address payable;

--- a/contracts/WithdrawableGetters.sol
+++ b/contracts/WithdrawableGetters.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IWithdrawableGetters } from "./interfaces/IWithdrawableGetters.sol";
+
+abstract contract WithdrawableGetters is IWithdrawableGetters {
+    /**
+     * @notice See {IWithdrawableGetters-withdrawable}.
+     */
+    function withdrawable(IERC20 token_) public view returns(uint256) {
+        return _withdrawable(token_, block.timestamp);
+    }
+
+    /**
+     * @notice See {IWithdrawableGetters-withdrawable}.
+     */
+    function withdrawable(IERC20 token_, uint256 timestamp) public view returns(uint256) {
+        return _withdrawable(token_, timestamp);
+    }
+
+    function _withdrawable(IERC20 token_, uint256 timestamp) internal view virtual returns(uint256) {}
+}

--- a/contracts/interfaces/IFarmingPlugin.sol
+++ b/contracts/interfaces/IFarmingPlugin.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.0;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPlugin } from "@1inch/token-plugins/contracts/interfaces/IPlugin.sol";
 import { FarmAccounting } from "../accounting/FarmAccounting.sol";
-
 interface IFarmingPlugin is IPlugin {
     event FarmCreated(address token, address reward);
     event DistributorChanged(address oldDistributor, address newDistributor);
     event RewardUpdated(uint256 reward, uint256 duration);
+    event FarmingStopped();
 
     // View functions
     function totalSupply() external view returns(uint256);
@@ -25,5 +25,5 @@ interface IFarmingPlugin is IPlugin {
 
     // Distributor functions
     function startFarming(uint256 amount, uint256 period) external;
-    function rescueFunds(IERC20 token, uint256 amount) external;
+    function rescueFunds(IERC20 token) external;
 }

--- a/contracts/interfaces/IFarmingPool.sol
+++ b/contracts/interfaces/IFarmingPool.sol
@@ -8,6 +8,7 @@ import { FarmAccounting } from "../accounting/FarmAccounting.sol";
 interface IFarmingPool is IERC20 {
     event DistributorChanged(address oldDistributor, address newDistributor);
     event RewardUpdated(uint256 reward, uint256 duration);
+    event FarmingStopped();
 
     // View functions
     function distributor() external view returns(address);
@@ -25,5 +26,5 @@ interface IFarmingPool is IERC20 {
 
     // Distributor functions
     function startFarming(uint256 amount, uint256 period) external;
-    function rescueFunds(IERC20 token, uint256 amount) external;
+    function rescueFunds(IERC20 token) external;
 }

--- a/contracts/interfaces/IMultiFarmingPlugin.sol
+++ b/contracts/interfaces/IMultiFarmingPlugin.sol
@@ -10,6 +10,7 @@ interface IMultiFarmingPlugin is IPlugin {
     event FarmCreated(address token, address reward);
     event DistributorChanged(address oldDistributor, address newDistributor);
     event RewardUpdated(address token, uint256 reward, uint256 duration);
+    event FarmingStopped();
 
     // View functions
     function totalSupply() external view returns(uint256);
@@ -26,5 +27,5 @@ interface IMultiFarmingPlugin is IPlugin {
 
     // Distributor functions
     function startFarming(IERC20 rewardsToken, uint256 amount, uint256 period) external;
-    function rescueFunds(IERC20 token, uint256 amount) external;
+    function rescueFunds(IERC20 token) external;
 }

--- a/contracts/interfaces/IWithdrawableGetters.sol
+++ b/contracts/interfaces/IWithdrawableGetters.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+
+interface IWithdrawableGetters {
+/**
+     * @notice Gets amount of tokens that can be withdrawn by the distributor.
+     * @param token_ Address of the token to be withdrawn
+     * @return Amount of tokens that can be withdrawn
+     */
+    function withdrawable(IERC20 token_) external view returns(uint256);
+
+    /**
+     * @notice Gets amount of tokens that can be withdrawn by the distributor at the specified timestamp.
+     * @param token_ Address of the token to be withdrawn
+     * @param timestamp Timestamp to calculate withdrawable amount
+     * @return Amount of tokens that can be withdrawn
+     */
+    function withdrawable(IERC20 token_, uint256 timestamp) external view returns(uint256);
+}

--- a/test/FarmingPlugin.js
+++ b/test/FarmingPlugin.js
@@ -2,6 +2,7 @@ const { expect, constants, time, ether } = require('@1inch/solidity-utils');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { ethers } = require('hardhat');
 const { almostEqual, startFarming, joinNewFarms } = require('./utils');
+const { Typed } = require('ethers');
 
 require('chai').use(function (chai, utils) {
     chai.Assertion.overwriteMethod('almostEqual', (_) => {
@@ -242,7 +243,7 @@ describe('FarmingPlugin', function () {
                 const distributor = await farm.distributor();
                 expect(wallet2).to.not.equal(distributor);
                 await expect(
-                    farm.connect(wallet2).rescueFunds(gift, '1000'),
+                    farm.connect(wallet2).rescueFunds(gift),
                 ).to.be.revertedWithCustomError(farm, 'AccessDenied');
             });
 
@@ -269,10 +270,10 @@ describe('FarmingPlugin', function () {
 
                 const distributor = await farm.distributor();
                 expect(wallet1.address).to.equal(distributor);
-                await farm.rescueFunds(gift, '1000');
+                await farm.rescueFunds(gift);
 
-                expect(await gift.balanceOf(wallet1)).to.equal(balanceWalletBefore + 1000n);
-                expect(await gift.balanceOf(farm)).to.equal(balanceFarmBefore - 1000n);
+                expect(await gift.balanceOf(wallet1)).to.equal(balanceWalletBefore + balanceFarmBefore);
+                expect(await gift.balanceOf(farm)).to.equal(0);
             });
 
             /*
@@ -302,43 +303,12 @@ describe('FarmingPlugin', function () {
 
                 const distributor = await farm.distributor();
                 expect(wallet1.address).to.equal(distributor);
-                const tx = await farm.rescueFunds(constants.ZERO_ADDRESS, '1000');
+                const tx = await farm.rescueFunds(constants.ZERO_ADDRESS);
                 const receipt = await tx.wait();
                 const txCost = receipt.gasUsed * receipt.gasPrice;
 
-                expect(await ethers.provider.getBalance(wallet1)).to.equal(balanceWalletBefore - txCost + 1000n);
-                expect(await ethers.provider.getBalance(farm)).to.equal(balanceFarmBefore - 1000n);
-            });
-
-            /*
-                ***Test Scenario**
-                Ensures that a distributor account cannot get funds that have been distributed
-                from the farm using the `rescueFunds` function.
-
-                ***Initial setup**
-                - A farm has started farming and distributed half of the reward tokens
-
-                ***Test Steps**
-                - Distributor calls the `rescueFunds` function to transfer 1000 reward tokens from the farm to its account
-
-                ***Expected results**
-                - Call is reverted with an error `'InsufficientFunds()'`
-            */
-            it('should thrown with insufficient funds', async function () {
-                const { gift, farm } = await loadFixture(initContracts);
-                const duration = BigInt(60 * 60 * 24);
-                await farm.startFarming(1000, duration);
-                await time.increaseTo((await farm.farmInfo()).finished - duration / 2n);
-
-                const balanceWalletBefore = await gift.balanceOf(wallet1);
-                const balanceFarmBefore = await gift.balanceOf(farm);
-
-                const distributor = await farm.distributor();
-                expect(wallet1.address).to.equal(distributor);
-                await expect(farm.rescueFunds(gift, '1000')).to.be.revertedWithCustomError(farm, 'InsufficientFunds');
-
-                expect(await gift.balanceOf(wallet1)).to.equal(balanceWalletBefore);
-                expect(await gift.balanceOf(farm)).to.equal(balanceFarmBefore);
+                expect(await ethers.provider.getBalance(wallet1)).to.equal(balanceWalletBefore - txCost + balanceFarmBefore);
+                expect(await ethers.provider.getBalance(farm)).to.equal(0);
             });
 
             /*
@@ -356,30 +326,29 @@ describe('FarmingPlugin', function () {
                 ***Expected results**
                 - 500 reward tokens are transferred from the farm to the distributor
                 - The farm's reward tokens amount is decreased by 500
-                - The farm's duration and finish time are decreased proportionally
+                - The farm's duration becomes 0 and finish is earlier than before
             */
             it('should transfer remaining reward tokens from farm to wallet', async function () {
                 const { gift, farm } = await loadFixture(initContracts);
                 const duration = BigInt(60 * 60 * 24);
-                const amount = 500n;
                 await farm.startFarming(1000, duration);
-                await time.increaseTo((await farm.farmInfo()).finished - duration / 2n);
+                const timestamp = (await farm.farmInfo()).finished - duration / 2n;
+                await time.increaseTo(timestamp);
 
                 const balanceWalletBefore = await gift.balanceOf(wallet1);
                 const balanceFarmBefore = await gift.balanceOf(farm);
-                const farmInfoBefore = await farm.farmInfo();
+                const finishedBefore = (await farm.farmInfo()).finished;
 
                 const distributor = await farm.distributor();
                 expect(wallet1.address).to.equal(distributor);
-                await farm.rescueFunds(gift, amount);
-                const newDuration = farmInfoBefore.duration * (farmInfoBefore.reward - amount) / farmInfoBefore.reward;
-                const newFinished = farmInfoBefore.finished - duration + newDuration;
+                const withdrawable = await farm.withdrawable(gift);
+                await farm.rescueFunds(gift);
 
-                expect(await gift.balanceOf(wallet1)).to.be.equal(balanceWalletBefore + amount);
-                expect(await gift.balanceOf(farm)).to.be.equal(balanceFarmBefore - amount);
-                expect((await farm.farmInfo()).reward).to.be.equal(farmInfoBefore.reward - amount);
-                expect((await farm.farmInfo()).duration).to.be.equal(newDuration);
-                expect((await farm.farmInfo()).finished).to.be.equal(newFinished);
+                expect(await gift.balanceOf(wallet1)).to.be.equal(balanceWalletBefore + withdrawable);
+                expect(await gift.balanceOf(farm)).to.be.equal(balanceFarmBefore - withdrawable);
+                expect((await farm.farmInfo()).reward).to.be.equal(0);
+                expect((await farm.farmInfo()).duration).to.be.equal(0);
+                expect((await farm.farmInfo()).finished).to.be.gte(timestamp).lt(finishedBefore);
             });
 
             /*
@@ -413,7 +382,7 @@ describe('FarmingPlugin', function () {
 
                 const distributor = await farm.distributor();
                 expect(wallet1.address).to.equal(distributor);
-                await farm.rescueFunds(token, amount);
+                await farm.rescueFunds(token);
 
                 expect(await token.balanceOf(wallet1)).to.be.equal(balanceWalletBefore + amount);
                 expect(await token.balanceOf(farm)).to.be.equal(balanceFarmBefore - amount);
@@ -518,6 +487,76 @@ describe('FarmingPlugin', function () {
                     const farmAddress = await token.pluginAt(wallet1, i);
                     expect(farmAddress).to.equal(farms[i]);
                 }
+            });
+        });
+
+        describe('withdrawable', function () {
+            it('should calculate correct withdrawable amount of tokens', async function () {
+                const { token, farm } = await loadFixture(initContracts);
+                const amount = 100n;
+                await token.mint(farm, amount);
+                const duration = BigInt(60 * 60 * 24);
+                await farm.startFarming(1000n, duration);
+
+                expect(await farm.withdrawable(token)).to.be.equal(amount);
+
+                await time.increaseTo((await farm.farmInfo()).finished - duration / 2n);
+                expect(await farm.withdrawable(token)).to.be.equal(amount);
+            });
+
+            it('should calculate correct withdrawable amount of ethers', async function () {
+                const { farm } = await loadFixture(initContracts);
+                const amount = 100n;
+
+                // Transfer ethers to farm
+                const EthTransferMock = await ethers.getContractFactory('EthTransferMock');
+                const ethMock = await EthTransferMock.deploy(farm, { value: amount });
+                await ethMock.waitForDeployment();
+
+                const duration = BigInt(60 * 60 * 24);
+                await farm.startFarming(1000n, duration);
+
+                expect(await farm.withdrawable(constants.ZERO_ADDRESS)).to.be.equal(amount);
+
+                await time.increaseTo((await farm.farmInfo()).finished - duration / 2n);
+                expect(await farm.withdrawable(constants.ZERO_ADDRESS)).to.be.equal(amount);
+            });
+
+            it('should calculate correct withdrawable amount of reward tokens', async function () {
+                const { gift, farm } = await loadFixture(initContracts);
+                const farmingAmount = 1000n;
+                const duration = BigInt(60 * 60 * 24);
+                await farm.startFarming(farmingAmount, duration);
+
+                expect(await farm.withdrawable(gift)).to.be.equal(farmingAmount);
+
+                await time.increaseTo((await farm.farmInfo()).finished - duration / 2n);
+                expect(await farm.withdrawable(gift)).to.be.equal(farmingAmount / 2n);
+            });
+
+            it('should calculate correct withdrawable amount of reward tokens at the specified timestamp', async function () {
+                const { gift, farm } = await loadFixture(initContracts);
+                const farmingAmount = 1000n;
+                const duration = BigInt(60 * 60 * 24);
+                await farm.startFarming(farmingAmount, duration);
+                const farmInfo = await farm.farmInfo();
+
+                // 0% of farming duration
+                let timestamp = farmInfo.finished - duration;
+                expect(await farm.withdrawable(gift, Typed.uint256(timestamp))).to.be.equal(farmingAmount);
+
+                // 25% of farming duration
+                timestamp += duration / 4n;
+                expect(await farm.withdrawable(gift, Typed.uint256(timestamp))).to.be.equal(farmingAmount * 3n / 4n);
+
+                // 75% of farming duration
+                timestamp += duration / 2n;
+                expect(await farm.withdrawable(gift, Typed.uint256((timestamp)))).to.be.equal(farmingAmount / 4n);
+
+                // 100% of farming duration
+                timestamp += duration / 4n;
+                expect((await farm.farmInfo()).finished).to.be.equal(timestamp);
+                expect(await farm.withdrawable(gift, Typed.uint256(timestamp))).to.be.equal(0);
             });
         });
     });

--- a/test/FarmingPlugin.js
+++ b/test/FarmingPlugin.js
@@ -407,23 +407,23 @@ describe('FarmingPlugin', function () {
                 - 2000 reward tokens are transferred from the farm to the distributor
                 - The farm's reward tokens amount becomes 0
             */
-                it('should transfer all remaining reward tokens from farm to wallet', async function () {
-                    const { gift, farm } = await loadFixture(initContracts);
-                    const duration = BigInt(60 * 60 * 24);
-                    const amount = 1000n;
-                    await farm.startFarming(amount, duration);
-                    await gift.mint(farm, amount);
+            it('should transfer all remaining reward tokens from farm to wallet', async function () {
+                const { gift, farm } = await loadFixture(initContracts);
+                const duration = BigInt(60 * 60 * 24);
+                const amount = 1000n;
+                await farm.startFarming(amount, duration);
+                await gift.mint(farm, amount);
     
-                    const balanceWalletBefore = await gift.balanceOf(wallet1);
-                    const balanceFarmBefore = await gift.balanceOf(farm);
+                const balanceWalletBefore = await gift.balanceOf(wallet1);
+                const balanceFarmBefore = await gift.balanceOf(farm);
 
-                    const distributor = await farm.distributor();
-                    expect(wallet1.address).to.equal(distributor);
-                    await farm.rescueFunds(gift);
+                const distributor = await farm.distributor();
+                expect(wallet1.address).to.equal(distributor);
+                await farm.rescueFunds(gift);
 
-                    expect(await gift.balanceOf(wallet1)).to.be.equal(balanceWalletBefore + amount * 2n);
-                    expect(await gift.balanceOf(farm)).to.be.equal(balanceFarmBefore - amount * 2n);
-                });
+                expect(await gift.balanceOf(wallet1)).to.be.equal(balanceWalletBefore + amount * 2n);
+                expect(await gift.balanceOf(farm)).to.be.equal(balanceFarmBefore - amount * 2n);
+            });
         });
 
         // Farm's plugins scenarios


### PR DESCRIPTION
The ability to specify amount of tokens that the distributor wants to rescue from the contract has been removed. Instead, all tokens available for withdrawal are sent to the distributor. As a result, if a reward token withdrawal is requested, the farm is not shortened in duration, but rather ended. View functions have also been added to get the number of tokens available for withdrawal at the current moment or at a specified timestamp.