### PR TITLE
[SC-929] Renamed `FarmAccounting` and `UserAccounting` libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ contract AMMPoolToken is ERC20Plugins {
 
 Storage access:
 
-- [1 storage slot](https://github.com/1inch/farming/blob/master/contracts/accounting/FarmAccounting.sol#L14-L16) for farming params, updated only on farming restarting:
+- [1 storage slot](https://github.com/1inch/farming/blob/master/contracts/libraries/Allocation.sol#L13-L15) for farming params, updated only when farming is restarted or stopped:
     
     ```solidity
     uint40 public finished;
@@ -121,14 +121,14 @@ Storage access:
     uint184 public reward;
     ```
     
-- [1 storage slot](https://github.com/1inch/farming/blob/master/contracts/accounting/UserAccounting.sol#L7-L8) for farming state, updated only on changing number of farming tokens:
+- [1 storage slot](https://github.com/1inch/farming/blob/master/contracts/libraries/Accounting.sol#L9-L10) for farming state, updated only on changing number of farming tokens:
     
     ```solidity
     uint40 public checkpoint;
     uint216 public farmedPerTokenStored;
     ```
     
-- [1 storage slot](https://github.com/1inch/farming/blob/master/contracts/accounting/UserAccounting.sol#L9) per each farmer, updated on deposits/withdrawals (kudos to [@snjax](https://github.com/snjax)):
+- [1 storage slot](https://github.com/1inch/farming/blob/master/contracts/libraries/Accounting.sol#L11) per each farmer, updated on deposits/withdrawals (kudos to [@snjax](https://github.com/snjax)):
     
     ```solidity
     mapping(address => int256) public corrections;

--- a/contracts/FarmingPlugin.sol
+++ b/contracts/FarmingPlugin.sol
@@ -11,12 +11,12 @@ import { IERC20Plugins } from "@1inch/token-plugins/contracts/interfaces/IERC20P
 
 import { IFarmingPlugin } from "./interfaces/IFarmingPlugin.sol";
 import { Distributor } from "./Distributor.sol";
-import { FarmingLib, FarmAccounting } from "./FarmingLib.sol";
+import { FarmingLib, Allocation } from "./libraries/FarmingLib.sol";
 
 contract FarmingPlugin is Plugin, IFarmingPlugin, Distributor {
     using SafeERC20 for IERC20;
     using FarmingLib for FarmingLib.Info;
-    using FarmAccounting for FarmAccounting.Info;
+    using Allocation for Allocation.Info;
     using Address for address payable;
 
     error ZeroFarmableTokenAddress();
@@ -37,8 +37,8 @@ contract FarmingPlugin is Plugin, IFarmingPlugin, Distributor {
         emit FarmCreated(address(farmableToken_), address(rewardsToken_));
     }
 
-    function farmInfo() public view returns(FarmAccounting.Info memory) {
-        return _farm.farmInfo;
+    function farmInfo() public view returns(Allocation.Info memory) {
+        return _farm.allocationInfo;
     }
 
     function totalSupply() public view returns(uint256) {
@@ -91,7 +91,7 @@ contract FarmingPlugin is Plugin, IFarmingPlugin, Distributor {
             payable(_distributor).sendValue(amount);
         } else {
             if (token_ == rewardsToken) {
-                if (rewardsToken.balanceOf(address(this)) < _farm.farmInfo.balance + amount) revert InsufficientFunds();
+                if (rewardsToken.balanceOf(address(this)) < _farm.allocationInfo.balance + amount) revert InsufficientFunds();
             }
             token_.safeTransfer(_distributor, amount);
         }

--- a/contracts/FarmingPool.sol
+++ b/contracts/FarmingPool.sol
@@ -10,7 +10,7 @@ import { SafeERC20 } from "@1inch/solidity-utils/contracts/libraries/SafeERC20.s
 
 import { IFarmingPool } from "./interfaces/IFarmingPool.sol";
 import { Distributor } from "./Distributor.sol";
-import { FarmAccounting, FarmingLib } from "./FarmingLib.sol";
+import { Allocation, FarmingLib } from "./libraries/FarmingLib.sol";
 
 contract FarmingPool is IFarmingPool, Distributor, ERC20 {
     using SafeERC20 for IERC20;
@@ -48,8 +48,8 @@ contract FarmingPool is IFarmingPool, Distributor, ERC20 {
         return IERC20Metadata(address(stakingToken)).decimals();
     }
 
-    function farmInfo() public view returns(FarmAccounting.Info memory) {
-        return _farm.farmInfo;
+    function farmInfo() public view returns(Allocation.Info memory) {
+        return _farm.allocationInfo;
     }
 
     function startFarming(uint256 amount, uint256 period) public virtual onlyDistributor {
@@ -104,7 +104,7 @@ contract FarmingPool is IFarmingPool, Distributor, ERC20 {
             if (token == stakingToken) {
                 if (stakingToken.balanceOf(address(this)) < totalSupply() + amount) revert InsufficientFunds();
             } else if (token == rewardsToken) {
-                if (rewardsToken.balanceOf(address(this)) < _farm.farmInfo.balance + amount) revert InsufficientFunds();
+                if (rewardsToken.balanceOf(address(this)) < _farm.allocationInfo.balance + amount) revert InsufficientFunds();
             }
 
             token.safeTransfer(_distributor, amount);

--- a/contracts/MultiFarmingPlugin.sol
+++ b/contracts/MultiFarmingPlugin.sol
@@ -12,7 +12,7 @@ import { IERC20Plugins } from "@1inch/token-plugins/contracts/interfaces/IERC20P
 
 import { IMultiFarmingPlugin } from "./interfaces/IMultiFarmingPlugin.sol";
 import { Distributor } from "./Distributor.sol";
-import { FarmAccounting, FarmingLib } from "./FarmingLib.sol";
+import { Allocation, FarmingLib } from "./libraries/FarmingLib.sol";
 
 contract MultiFarmingPlugin is Plugin, IMultiFarmingPlugin, Distributor {
     using SafeERC20 for IERC20;
@@ -46,8 +46,8 @@ contract MultiFarmingPlugin is Plugin, IMultiFarmingPlugin, Distributor {
         return _rewardsTokens.items.get();
     }
 
-    function farmInfo(IERC20 rewardsToken) public view returns(FarmAccounting.Info memory) {
-        return _farms[rewardsToken].farmInfo;
+    function farmInfo(IERC20 rewardsToken) public view returns(Allocation.Info memory) {
+        return _farms[rewardsToken].allocationInfo;
     }
 
     function totalSupply() public view returns(uint256) {
@@ -132,7 +132,7 @@ contract MultiFarmingPlugin is Plugin, IMultiFarmingPlugin, Distributor {
             payable(_distributor).sendValue(amount);
         } else {
             if (_rewardsTokens.contains(address(token_))) {
-                if (token_.balanceOf(address(this)) < _farms[token_].farmInfo.balance + amount) revert InsufficientFunds();
+                if (token_.balanceOf(address(this)) < _farms[token_].allocationInfo.balance + amount) revert InsufficientFunds();
             }
             token_.safeTransfer(_distributor, amount);
         }

--- a/contracts/interfaces/IFarmingPlugin.sol
+++ b/contracts/interfaces/IFarmingPlugin.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPlugin } from "@1inch/token-plugins/contracts/interfaces/IPlugin.sol";
-import { FarmAccounting } from "../accounting/FarmAccounting.sol";
+import { Allocation } from "../libraries/Allocation.sol";
 
 interface IFarmingPlugin is IPlugin {
     event FarmCreated(address token, address reward);
@@ -12,7 +12,7 @@ interface IFarmingPlugin is IPlugin {
 
     // View functions
     function totalSupply() external view returns(uint256);
-    function farmInfo() external view returns(FarmAccounting.Info memory);
+    function farmInfo() external view returns(Allocation.Info memory);
     function farmed(address account) external view returns(uint256);
 
     // User functions

--- a/contracts/interfaces/IFarmingPool.sol
+++ b/contracts/interfaces/IFarmingPool.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { FarmAccounting } from "../accounting/FarmAccounting.sol";
+import { Allocation } from "../libraries/Allocation.sol";
 
 interface IFarmingPool is IERC20 {
     event RewardUpdated(uint256 reward, uint256 duration);
 
     // View functions
-    function farmInfo() external view returns(FarmAccounting.Info memory);
+    function farmInfo() external view returns(Allocation.Info memory);
     function farmed(address account) external view returns(uint256);
 
     // User functions

--- a/contracts/interfaces/IMultiFarmingPlugin.sol
+++ b/contracts/interfaces/IMultiFarmingPlugin.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IPlugin } from "@1inch/token-plugins/contracts/interfaces/IPlugin.sol";
-import { FarmAccounting } from "../accounting/FarmAccounting.sol";
+import { Allocation } from "../libraries/Allocation.sol";
 
 interface IMultiFarmingPlugin is IPlugin {
     event FarmCreated(address token, address reward);
@@ -12,7 +12,7 @@ interface IMultiFarmingPlugin is IPlugin {
 
     // View functions
     function totalSupply() external view returns(uint256);
-    function farmInfo(IERC20 rewardsToken) external view returns(FarmAccounting.Info memory);
+    function farmInfo(IERC20 rewardsToken) external view returns(Allocation.Info memory);
     function farmed(IERC20 rewardsToken, address account) external view returns(uint256);
 
     // User functions

--- a/contracts/libraries/Accounting.sol
+++ b/contracts/libraries/Accounting.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import { FarmAccounting } from "./FarmAccounting.sol";
+import { Allocation } from "./Allocation.sol";
 
-library UserAccounting {
+library Accounting {
     struct Info {
         uint40 checkpoint;
         uint216 farmedPerTokenStored;
@@ -30,7 +30,7 @@ library UserAccounting {
 
     function farmed(Info storage info, address account, uint256 balance, uint256 fpt) internal view returns(uint256) {
         // balance * fpt is less than 168 bit
-        return uint256(int256(balance * fpt) - info.corrections[account]) / FarmAccounting._SCALE;
+        return uint256(int256(balance * fpt) - info.corrections[account]) / Allocation._SCALE;
     }
 
     function eraseFarmed(Info storage info, address account, uint256 balance, uint256 fpt) internal {

--- a/contracts/libraries/Allocation.sol
+++ b/contracts/libraries/Allocation.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
-library FarmAccounting {
+library Allocation {
     error ZeroDuration();
     error DurationTooLarge();
     error AmountTooLarge();
@@ -31,7 +31,7 @@ library FarmAccounting {
         }
     }
 
-    function startFarming(Info storage info, uint256 amount, uint256 period) internal returns(uint256) {
+    function allocate(Info storage info, uint256 amount, uint256 period) internal returns(uint256) {
         if (period == 0) revert ZeroDuration();
         if (period > type(uint32).max) revert DurationTooLarge();
 
@@ -52,7 +52,7 @@ library FarmAccounting {
         return amount;
     }
 
-    function stopFarming(Info storage info) internal returns(uint256 leftover) {
+    function terminateAllocation(Info storage info) internal returns(uint256 leftover) {
         leftover = info.reward - farmedSinceCheckpointScaled(info, info.finished - info.duration) / _SCALE;
         (info.finished, info.duration, info.reward, info.balance) = (
             uint40(block.timestamp),

--- a/test/FarmingPlugin.js
+++ b/test/FarmingPlugin.js
@@ -334,14 +334,14 @@ describe('FarmingPlugin', function () {
                 const duration = BigInt(60 * 60 * 24);
                 await farm.startFarming(1000, duration);
                 await time.increaseTo((await farm.farmInfo()).finished + 1n);
-    
+
                 const balanceWalletBefore = await gift.balanceOf(wallet1);
                 const balanceFarmBefore = await gift.balanceOf(farm);
-    
+
                 const distributor = await farm.distributor();
                 expect(wallet1.address).to.equal(distributor);
                 await farm.stopFarming();
-    
+
                 expect(await gift.balanceOf(wallet1)).to.be.equal(balanceWalletBefore);
                 expect(await gift.balanceOf(farm)).to.be.equal(balanceFarmBefore);
                 expect((await farm.farmInfo()).reward).to.be.equal(0);


### PR DESCRIPTION
- Renamed `accounting` folder to `libraries` and moved `FarmingLib` there.
- Renamed `FarmAccounting` =>`Allocation`, `UserAccounting` => `Accounting`.
- Renamed `FarmAccounting.startFarming` => `allocate`, `stopFarming` => `terminateAllocation`.