### PR TITLE
Fix farming balance inflation bug

### DIFF
--- a/contracts/accounting/FarmAccounting.sol
+++ b/contracts/accounting/FarmAccounting.sol
@@ -31,22 +31,23 @@ library FarmAccounting {
         }
     }
 
-    function startFarming(Info storage info, uint256 amount, uint256 period) internal returns(uint256) {
+    function startFarming(Info storage info, uint256 amount, uint256 period) internal returns(uint256 newAmount) {
         if (period == 0) revert ZeroDuration();
         if (period > type(uint32).max) revert DurationTooLarge();
 
+        newAmount = amount;
         // If something left from prev farming add it to the new farming
         (uint40 finished, uint32 duration, uint184 reward, uint256 balance) = (info.finished, info.duration, info.reward, info.balance);
         if (block.timestamp < finished) {
-            amount += reward - farmedSinceCheckpointScaled(info, finished - duration) / _SCALE;
+            newAmount += reward - farmedSinceCheckpointScaled(info, finished - duration) / _SCALE;
         }
 
-        if (amount > _MAX_REWARD_AMOUNT) revert AmountTooLarge();
+        if (newAmount > _MAX_REWARD_AMOUNT) revert AmountTooLarge();
 
         (info.finished, info.duration, info.reward, info.balance) = (
             uint40(block.timestamp + period),
             uint32(period),
-            uint184(amount),
+            uint184(newAmount),
             balance + amount
         );
         return amount;


### PR DESCRIPTION
## What Was Wrong

In `FarmAccounting.startFarming(...)`, when starting a new farming period before the previous one ends, the leftover from the previous reward is added to `amount`. Then, the full `amount` (which now includes the leftover) is added to `info.balance`:

## The Problem

`info.balance` should reflect only the actual tokens transferred to the contract via `safeTransferFrom` in `startFarming`.  
However, `leftover` was already on the contract and previously accounted for in the last `reward`.

As a result:

- `info.balance` becomes inflated, it includes both the newly transferred amount and already existing leftover
- an inconsistency arises between internal accounting (`info.balance`) and the actual token balance of the contract

## Why It Matters

- `rescueFunds()` may allow withdrawal of “excess” tokens that are still needed for payouts
- `claim()` may unexpectedly revert if the inflated `balance` doesn’t match the actual token balance

## What Was Fixed

Now, `info.balance` is increased only by the `amount` passed to `startFarming`, which matches the actual `safeTransferFrom`.  
The `leftover` is still used to increase `reward`, but it’s no longer double-counted in the internal `balance`
